### PR TITLE
use idle API to avoid potential issues mentioned in #126

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,4 +1,4 @@
-var { storage, runtime, browserAction, pageAction, tabs, windows, menus, extension } = browser;
+var { storage, runtime, browserAction, pageAction, tabs, windows, menus, extension, idle } = browser;
 var { local } = storage;
 
 var catchErr = e => console.error(e);

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
     "48": "icons/icon.png"
   },
 
-  "permissions": ["storage", "clipboardWrite", "menus", "alarms"],
+  "permissions": ["storage", "clipboardWrite", "menus", "alarms", "idle"],
 
   "browser_action": {
     "browser_style": true,

--- a/ta_bg.js
+++ b/ta_bg.js
@@ -230,10 +230,6 @@ ta_bg.setupAutoClear = () => {
     // should remove alarm when shouldAutoClear is set to false
     // and add back when shouldAutoClear is set to true
 
-    browser.alarms.create('check-auto-clear', {
-        periodInMinutes: 1
-    });
-
     var checkAutoClear = () => {
         var data = ta_database.data;
 
@@ -263,6 +259,13 @@ ta_bg.setupAutoClear = () => {
         }
     };
 
-    browser.alarms.onAlarm.addListener(checkAutoClear);
-    checkAutoClear();
+    var checkAutoClearListener = idleState => {
+        if (!["idle", "locked"].includes(idleState)) {
+            return;
+        }
+        checkAutoClear();
+    };
+    idle.setDetectionInterval(180);  // 3 minutes.
+    idle.onStateChanged.removeListener(checkAutoClearListener);  // avoids repetitive call
+    idle.onStateChanged.addListener(checkAutoClearListener);
 };


### PR DESCRIPTION
issue #126 mentioned that after the bug is fixed, AutoClear back online, on its first execution, many users (like me) who has already accumulated years of cache could experience a huge lag. Another potential issue is that users might have unexpected cache lost due to 'check-auto-clear' alarm mechanism and the immediate effect of options changing event.

The solution is to replace the too frequent 1-minute-alarm by the browser.idle API, as I mentioned before:

(quote) Firstly, during checkAutoClear()'s first run, it will have enough time to clean up all outdated cache, while the next run will be when user come back to the computer, do some activity, and leave the computer again for 3 min. This should avoid overlaps. 
Secondly, people like me may prefer to keep a relatively heavy cache (from months to 1 year), so each checkAutoClear() run might cause perceptible lags in the worst-case scenario. Instead of doing it once a minute, it's better to do it when the user is away from keyboard. 
Thirdly, users may not be aware that **any change in options takes effect immediately**, so when AutoClear is back, a user might unintentionally change autoClear_day from 210 to 10 before he types 310. If the old 'check-auto-clear' alarm happens to fire up when autoClear_day value is 10, then the user would **unexpectedly lose 200 days of cache**. Using the idle API avoids this.

Plus, this is also the way how the [Expire History By Days](https://addons.mozilla.org/zh-CN/firefox/addon/expire-history-by-days) addon does the auto-clear.