### PR TITLE
fixed bugs in ta_database.updateDatabaseVersion()

### DIFF
--- a/ta_database.js
+++ b/ta_database.js
@@ -43,7 +43,7 @@ var ta_database = {
         var me = ta_database;
 
         for (var key in me.data) {
-            if (key == 'setting') continue;
+            if (["version", "setting", "exceptions"].includes(key)) continue;
 
             let { last_modified } = me.data[key];
 

--- a/ta_database.js
+++ b/ta_database.js
@@ -59,8 +59,9 @@ var ta_database = {
             me.set(key, me.data[key]);
         }
 
-        if (me.data.setting.version != me.VERSION) {
-            me.data.setting.version = me.VERSION;
+        if (me.data.version != me.VERSION) {
+            me.data.version = me.VERSION;
+            await me.set('version', me.data.version);
             await me.set('setting', me.data.setting);
         }
     },

--- a/ta_database.js
+++ b/ta_database.js
@@ -62,7 +62,24 @@ var ta_database = {
         if (me.data.version != me.VERSION) {
             me.data.version = me.VERSION;
             await me.set('version', me.data.version);
-            await me.set('setting', me.data.setting);
+        }
+
+        if (me.data.setting == undefined) me.data.setting = me._resetData.setting;
+        for (var key in me._resetData.setting) {
+            if (me.data.setting[key] == undefined) {
+                me.data.setting[key] = me._resetData.setting[key];
+            }
+        }
+        for (var key in me.data.setting) {
+            if (me._resetData.setting[key] == undefined) {
+                delete me.data.setting[key];
+            }
+        }
+        await me.set('setting', me.data.setting);
+
+        if (me.data.exceptions == undefined) {
+            me.data.exceptions = me._resetData.exceptions;
+            await me.set('exceptions', me.data.exceptions);
         }
     },
 

--- a/ta_database.js
+++ b/ta_database.js
@@ -56,7 +56,7 @@ var ta_database = {
             else {
                 me.data[key].last_modified = me.data[key].time;
             }
-            me.set(key, me.data[key]);
+            await me.set(key, me.data[key]);
         }
 
         if (me.data.version != me.VERSION) {


### PR DESCRIPTION
Several things fixed:
1. A piece of code correctly updated 'setting' in the database by comparing data.setting to _resetData.setting, but that code got deleted for no reason in the commit a6efa62 . I put it back.
2. The code for updating 'version' in the commit 07b3e88 had mistaken me.data.setting.version for me.data.version
3. Only 'setting' was skipped in the for-loop, which is not right
4. Now correctly updates 'setting' and 'exceptions', deleting option values that are not in _resetData.setting