### PR TITLE
Remove console.log statement from findTextContentInterval

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -94,7 +94,6 @@ var tcl = {
         while (true) {
             await sleep(ms);
             await waitPageVisible();
-            console.log('find interval')
             me.findTextContentsAndAttachEvents();
         }
     },


### PR DESCRIPTION
This is currently spamming my console. Aside from this, fantastic addon! it's saved me so many times.